### PR TITLE
Fix crash in GetStaticMeshSection

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
@@ -691,7 +691,7 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 					uint32 StartIndex = Section.FirstIndex * 4;
 					uint32 NumIndices = Section.NumTriangles * 3 * 4;
 
-					for (uint32 Index = 0; Index < NumIndices; Index++)
+					for (uint32 Index = StartIndex; Index < NumIndices; Index++)
 					{
 						AdjacencyIndexCreator(MeshToSectionVertMap[AdjacencyIndices[Index]]);
 					}


### PR DESCRIPTION
Using URuntimeMeshLibrary::GetStaticMeshSection caused a crash because URuntimeMeshLibrary::GetStaticMeshSection was referencing indices that didn't exist in MeshToSectionVertMap.

It looks like the intention was to iterate from StartIndex to NumIndices, but 0 was used instead of StartIndex.