### PR TITLE
added API to retrieve generated mesh data

### DIFF
--- a/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
@@ -325,6 +325,12 @@ public:
 		GetRuntimeMeshData()->UpdateMeshSectionTriangles<IndexType>(SectionId, InTriangles, UpdateFlags);
 	}
 
+    template<typename VertexType, typename IndexType>
+    FORCEINLINE void GetMeshSectionData(int32 SectionIndex, TArray<VertexType>& OutVertices, TArray<IndexType>& OutTriangles)
+    {
+		check(IsInGameThread());
+        GetRuntimeMeshData()->GetMeshSectionData(SectionIndex, OutVertices, OutTriangles);
+    }
 
 
 	FORCEINLINE void CreateMeshSection(int32 SectionId, const TSharedPtr<FRuntimeMeshBuilder>& MeshData, bool bCreateCollision = false,

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -379,6 +379,11 @@ public:
 		GetOrCreateRuntimeMesh()->UpdateMeshSectionTripleBuffer(SectionId, InVertices0, InVertices1, InVertices2, InTriangles, BoundingBox, UpdateFlags);
 	}
 
+    template<typename VertexType, typename IndexType>
+    FORCEINLINE void GetMeshSectionData(int32 SectionIndex, TArray<VertexType>& OutVertices, TArray<IndexType>& OutTriangles)
+    {
+        GetOrCreateRuntimeMesh()->GetMeshSectionData(SectionIndex, OutVertices, OutTriangles);
+    }
 
 
 

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
@@ -917,6 +917,20 @@ public:
 	void UpdateMeshSectionPacked_Blueprint(int32 SectionIndex, const TArray<FRuntimeMeshBlueprintVertexSimple>& Vertices, const TArray<int32>& Triangles,
 		bool bCalculateNormalTangent = false, bool bShouldCreateHardTangents = false, bool bGenerateTessellationTriangles = false);
 
+    void GetMeshSectionData(int32 SectionIndex, TArray<FVector>& OutVertices, TArray<int32>& OutTriangles)
+    {
+        TSharedPtr<const FRuntimeMeshAccessor> acc = GetReadonlyMeshAccessor(SectionIndex);
+        int32 vertCount = acc->NumVertices();
+        OutVertices.SetNum(vertCount, true);
+        for (int32 i=0; i < vertCount; i++)
+            OutVertices[i] = acc->GetPosition(i);
+
+        int32 indexCount = acc->NumIndices();
+        OutTriangles.SetNum(indexCount, true);
+        for (int32 i=0; i < indexCount; i++)
+            OutTriangles[i] = acc->GetIndex(i);
+    }
+
 	
 
 


### PR DESCRIPTION
In our app, RMC data is generated in a number of different ways in a number of different places, and then we have a need to export that generated data, but we couldn't find a way to get the vertex and face info out of the RMC. This patch adds that functionality.